### PR TITLE
Build libpcre2 directly on the runner

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make install
+        wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make && sudo make install
         sudo cpanm YAML::XS
         sudo cpanm Carp::Assert
         sudo cpanm Try::Tiny

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,7 +46,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install libpcre2-dev
+# libpcre2 version on Ubuntu 20.04 LTS is too old
+#        sudo apt install libpcre2-dev
+        wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make install
         sudo cpanm YAML::XS
         sudo cpanm Carp::Assert
         sudo cpanm Try::Tiny

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make && sudo make install
+        pushd $(mktemp -d) && wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make && sudo make install && popd
         sudo cpanm YAML::XS
         sudo cpanm Carp::Assert
         sudo cpanm Try::Tiny

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,8 +46,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-# libpcre2 version on Ubuntu 20.04 LTS is too old
-#        sudo apt install libpcre2-dev
         wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz && tar -xf pcre2-10.45.tar.gz && cd pcre2-10.45 && ./configure && make install
         sudo cpanm YAML::XS
         sudo cpanm Carp::Assert


### PR DESCRIPTION
The Ubuntu LTS ships a version of libpcre2(-dev) that's too old and is missing symbols regex-pcre2 uses. I don't see any explicit versioning in the regex-pcre2 docs, but 10.45 seems to work just fine with regex-pcre2 v1.0.0.0.
So let's try to build libpcre2 v10.45 on the runner.